### PR TITLE
Configure build-scan plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ sudo: true
 install: true
 
 script:
- - ./gradlew  -S clean build --console=plain --info
+ - ./gradlew  -S clean build --console=plain --info --scan
 
 jdk:
  - oraclejdk8

--- a/build.gradle
+++ b/build.gradle
@@ -16,12 +16,18 @@
 // PLEASE NOTE: Integration Tests and Gradle Compatibility tests download a number of files.
 
 plugins {
+    id 'com.gradle.build-scan' version '2.2.1'
     id 'groovy'
     id 'maven'
     id 'com.gradle.plugin-publish' version '0.9.9'
     id 'com.github.hierynomus.license' version '0.12.1'
     id 'org.ysb33r.gradletest' version '2.0-beta.3'
     id 'org.ysb33r.os' version '0.9'
+}
+
+buildScan {
+    termsOfServiceUrl   = 'https://gradle.com/terms-of-service'
+    termsOfServiceAgree = 'yes'
 }
 
 apply from: 'gradle/integration-tests.gradle'

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.daemon   = true
+org.gradle.caching  = true
+org.gradle.parallel = true


### PR DESCRIPTION
This small PR configures the `build-scan` Gradle plugin (https://guides.gradle.org/creating-build-scans/) which yields further insight into the build, allowing the team to make informed decisions on where and when the build may be tweaked to get faster, more performant builds.