### PR TITLE
Added realm parameter for credentials (fix for #29)

### DIFF
--- a/src/main/groovy/org/ysb33r/gradle/ivypot/OfflineRepositorySync.groovy
+++ b/src/main/groovy/org/ysb33r/gradle/ivypot/OfflineRepositorySync.groovy
@@ -321,7 +321,11 @@ class OfflineRepositorySync extends DefaultTask {
         this.repositories.each {
             if (it.metaClass.respondsTo(it, 'getCredentials')) {
                 if (it.credentials.username && it.credentials.password) {
-                    xml += "<credentials host='${it.url.host}' username='${it.credentials.username}' passwd='${it.credentials.password}'/>"
+                    xml += "<credentials host='${it.url.host}' username='${it.credentials.username}' passwd='${it.credentials.password}' "
+                    if (it.credentials.realm) {
+                        xml += "realm='${it.credentials.realm}' "
+                    }
+                    xml += "/>"
                 }
             }
         }

--- a/src/main/groovy/org/ysb33r/gradle/ivypot/internal/Credentials.groovy
+++ b/src/main/groovy/org/ysb33r/gradle/ivypot/internal/Credentials.groovy
@@ -25,7 +25,9 @@ import org.gradle.api.artifacts.repositories.PasswordCredentials
 class Credentials implements PasswordCredentials {
     String username
     String password
+    String realm
 
     void username(final String s) {this.username=s}
     void password(final String s) {this.password=s}
+    void realm(final String s) {this.realm=s}
 }


### PR DESCRIPTION
I had the same problem as issue #29 when I tried to access an authenticated Nexus repository via Ivypot.
The issue seems to be that our company repository uses a different authentication realm which must be configured in the ivysettings.xml that is generated by ivypot.

You can check this if you run your gradle build with debug logging and see something like this:

```
[sun.net.www.protocol.http.HttpURLConnection] sun.net.www.MessageHeader@3ca1f0a97 pairs: {null: HTTP/1.1 401 Unauthorized}{Date: Tue, 02 Apr 2019 09:54:02 GMT}{Server: Apache}{WWW-Authenticate: Basic realm="MyRealm"}
```

In this case "MyRealm" is the realm which must be configured in ivysettings.xml.

Since the file is always regenerated by Ivypot, I prepared a fix which adds the realm property to the credentials and writes the value to the generated ivysettings.xml file. Afterwards I could resolve my dependencies without any issues my defining my repository like this:

```
maven {
	url "https://repo.server.com/"
	credentials {
		username "MyUser"
		password "MyPassword"
		realm "MyRealm"
	}
}
```